### PR TITLE
[1주차] 1주차 세미나 선택 과제

### DIFF
--- a/src/main/java/org/sopt/week1/Diary.java
+++ b/src/main/java/org/sopt/week1/Diary.java
@@ -1,12 +1,16 @@
 package org.sopt.week1;
 
+import java.time.LocalDate;
+
 public class Diary {
     private Long id;
     private String body;
+    private final ReviseInfo reviseInfo;
 
     public Diary(Long id, String body) {
         this.id = id;
         this.body = body;
+        this.reviseInfo = new ReviseInfo();
     }
 
     public Long getId() {
@@ -19,5 +23,13 @@ public class Diary {
 
     public void updateBody(String body) {
         this.body = body;
+        reviseInfo.updateReviseCount();
+    }
+
+    public boolean checkReviseCount() {
+        if (reviseInfo.getReviseDate().isBefore(LocalDate.now())) {
+            reviseInfo.resetReviseCount();
+        }
+        return reviseInfo.checkReviseCount();
     }
 }

--- a/src/main/java/org/sopt/week1/DiaryController.java
+++ b/src/main/java/org/sopt/week1/DiaryController.java
@@ -35,6 +35,10 @@ public class DiaryController {
         diaryService.reviseDiary(id, body);
     }
 
+    public void restore(String id) {
+        diaryService.restoreDiary(id);
+    }
+
     enum Status {
         READY,
         RUNNING,

--- a/src/main/java/org/sopt/week1/DiaryRepository.java
+++ b/src/main/java/org/sopt/week1/DiaryRepository.java
@@ -27,18 +27,22 @@ public class DiaryRepository {
         return diaries;
     }
 
-    protected void delete(Diary diary) {
+    protected void delete(final Diary diary) {
         storage.remove(diary.getId());
     }
 
-    protected void revise(Diary diary) {
+    protected void revise(final Diary diary) {
         storage.put(diary.getId(), diary.getBody());
     }
 
-    protected Diary findById(long id) {
+    protected Diary findById(final long id) {
         if (!storage.containsKey(id)) {
             throw new InvalidInputException("존재하지 않는 id 입니다.");
         }
         return new Diary(id, storage.get(id));
+    }
+
+    protected void restore(final Diary diary) {
+        storage.put(diary.getId(), diary.getBody());
     }
 }

--- a/src/main/java/org/sopt/week1/DiaryRepository.java
+++ b/src/main/java/org/sopt/week1/DiaryRepository.java
@@ -8,20 +8,19 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class DiaryRepository {
-    private final Map<Long, String> storage = new ConcurrentHashMap<>();
+    private final Map<Long, Diary> storage = new ConcurrentHashMap<>();
     private final AtomicLong numbering = new AtomicLong();
 
-    protected void save(final Diary diary) {
+    protected void save(final String body) {
         final long id = numbering.addAndGet(1);
-        storage.put(id, diary.getBody());
+        storage.put(id, new Diary(id, body));
     }
 
     protected List<Diary> findAll() {
         final List<Diary> diaries = new ArrayList<>();
         for(long idx = 1; idx <= numbering.longValue(); idx++) {
             if (storage.containsKey(idx)) {
-                final String body = storage.get(idx);
-                diaries.add(new Diary(idx, body));
+                diaries.add(storage.get(idx));
             }
         }
         return diaries;
@@ -32,17 +31,17 @@ public class DiaryRepository {
     }
 
     protected void revise(final Diary diary) {
-        storage.put(diary.getId(), diary.getBody());
+        storage.put(diary.getId(), diary);
     }
 
     protected Diary findById(final long id) {
         if (!storage.containsKey(id)) {
             throw new InvalidInputException("존재하지 않는 id 입니다.");
         }
-        return new Diary(id, storage.get(id));
+        return storage.get(id);
     }
 
     protected void restore(final Diary diary) {
-        storage.put(diary.getId(), diary.getBody());
+        storage.put(diary.getId(), diary);
     }
 }

--- a/src/main/java/org/sopt/week1/DiaryService.java
+++ b/src/main/java/org/sopt/week1/DiaryService.java
@@ -5,6 +5,7 @@ import org.sopt.week1.Main.UI.InvalidInputException;
 
 public class DiaryService {
     private final DiaryRepository diaryRepository = new DiaryRepository();
+    private final TrashBin trashBin = new TrashBin();
 
     public List<Diary> getDiaryList() {
         return diaryRepository.findAll();
@@ -18,7 +19,9 @@ public class DiaryService {
 
     public void deleteDiary(final String id) {
         long diaryId = convertIdToLong(id);
-        diaryRepository.delete(diaryRepository.findById(diaryId));
+        Diary diary = diaryRepository.findById(diaryId);
+        diaryRepository.delete(diary);
+        trashBin.pile(diary);
     }
 
     public void reviseDiary(final String id, final String body) {
@@ -27,6 +30,10 @@ public class DiaryService {
         Diary diary = diaryRepository.findById(diaryId);
         diary.updateBody(body);
         diaryRepository.revise(diary);
+    }
+
+    public void restoreDiary(String id) {
+        diaryRepository.restore(trashBin.restore(convertIdToLong(id)));
     }
 
     private long convertIdToLong(final String id) {

--- a/src/main/java/org/sopt/week1/DiaryService.java
+++ b/src/main/java/org/sopt/week1/DiaryService.java
@@ -32,7 +32,7 @@ public class DiaryService {
         diaryRepository.revise(diary);
     }
 
-    public void restoreDiary(String id) {
+    public void restoreDiary(final String id) {
         diaryRepository.restore(trashBin.restore(convertIdToLong(id)));
     }
 

--- a/src/main/java/org/sopt/week1/DiaryService.java
+++ b/src/main/java/org/sopt/week1/DiaryService.java
@@ -13,8 +13,7 @@ public class DiaryService {
 
     public void writeDiary(final String body) {
         checkBodyLength(body);
-        Diary diary = new Diary(null, body);
-        diaryRepository.save(diary);
+        diaryRepository.save(body);
     }
 
     public void deleteDiary(final String id) {
@@ -28,6 +27,7 @@ public class DiaryService {
         long diaryId = convertIdToLong(id);
         checkBodyLength(body);
         Diary diary = diaryRepository.findById(diaryId);
+        validateReviseCount(diary);
         diary.updateBody(body);
         diaryRepository.revise(diary);
     }
@@ -44,7 +44,7 @@ public class DiaryService {
 
     private long convertIdToLong(final String id) {
         try {
-            return Long.valueOf(id);
+            return Long.parseLong(id);
         } catch (NumberFormatException e) {
             throw new InvalidInputException("유효한 숫자가 아닙니다.");
         }
@@ -53,6 +53,12 @@ public class DiaryService {
     private void checkBodyLength(final String body) {
         if (body.codePointCount(0, body.length()) > 30) {
             throw new InvalidInputException("최대 글자 수(30자)를 초과하였습니다.");
+        }
+    }
+
+    private void validateReviseCount(final Diary diary) {
+        if (!diary.checkReviseCount()) {
+            throw new InvalidInputException("일일 수정 횟수(2회)를 모두 소모했습니다.");
         }
     }
 }

--- a/src/main/java/org/sopt/week1/DiaryService.java
+++ b/src/main/java/org/sopt/week1/DiaryService.java
@@ -33,11 +33,13 @@ public class DiaryService {
     }
 
     public void restoreDiary(final String id) {
-        trashBin.restore(convertIdToLong(id))
+        long diaryId = convertIdToLong(id);
+        trashBin.restore(diaryId)
                 .ifPresentOrElse(diaryRepository::restore,
                         () -> {
                             throw new InvalidInputException("삭제되지 않는 id 입니다.");
                         });
+        trashBin.remove(diaryId);
     }
 
     private long convertIdToLong(final String id) {

--- a/src/main/java/org/sopt/week1/DiaryService.java
+++ b/src/main/java/org/sopt/week1/DiaryService.java
@@ -33,7 +33,11 @@ public class DiaryService {
     }
 
     public void restoreDiary(final String id) {
-        diaryRepository.restore(trashBin.restore(convertIdToLong(id)));
+        trashBin.restore(convertIdToLong(id))
+                .ifPresentOrElse(diaryRepository::restore,
+                        () -> {
+                            throw new InvalidInputException("삭제되지 않는 id 입니다.");
+                        });
     }
 
     private long convertIdToLong(final String id) {

--- a/src/main/java/org/sopt/week1/Main.java
+++ b/src/main/java/org/sopt/week1/Main.java
@@ -98,6 +98,11 @@ public class Main {
 
                             server.patch(inputId, inputBody);
                         }
+                        case "RESTORE" -> {
+                            ConsoleIO.printLine("복구할 일기의 id 를 입력하세요!");
+                            final String inputId = ConsoleIO.readLine();
+                            server.restore(inputId);
+                        }
                         case "FINISH" -> {
                             server.finish();
                         }
@@ -129,6 +134,7 @@ public class Main {
                     - POST : 일기 작성하기
                     - DELETE : 일기 제거하기
                     - PATCH : 일기 수정하기
+                    - RESTORE : 일기 복구하기
                     """;
 
         }

--- a/src/main/java/org/sopt/week1/ReviseInfo.java
+++ b/src/main/java/org/sopt/week1/ReviseInfo.java
@@ -1,0 +1,31 @@
+package org.sopt.week1;
+
+import java.time.LocalDate;
+
+public class ReviseInfo {
+    private static final int REVISE_LIMIT = 2;
+    private LocalDate reviseDate;
+    private int reviseCount;
+
+    public ReviseInfo() {
+        this.reviseDate = LocalDate.now();
+        this.reviseCount = 0;
+    }
+
+    public LocalDate getReviseDate() {
+        return reviseDate;
+    }
+
+    public void updateReviseCount() {
+        reviseCount++;
+        reviseDate = LocalDate.now();
+    }
+
+    public void resetReviseCount() {
+        reviseCount = 0;
+    }
+
+    public boolean checkReviseCount() {
+        return reviseCount < REVISE_LIMIT;
+    }
+}

--- a/src/main/java/org/sopt/week1/TrashBin.java
+++ b/src/main/java/org/sopt/week1/TrashBin.java
@@ -5,20 +5,20 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class TrashBin {
-    private final Map<Long, String> trashCan = new ConcurrentHashMap<>();
+    private final Map<Long, Diary> trashCan = new ConcurrentHashMap<>();
 
-    protected void pile(Diary diary) {
-        trashCan.put(diary.getId(), diary.getBody());
+    protected void pile(final Diary diary) {
+        trashCan.put(diary.getId(), diary);
     }
 
-    protected Optional<Diary> restore(long id) {
+    protected Optional<Diary> restore(final long id) {
         if (!trashCan.containsKey(id)) {
             return Optional.empty();
         }
-        return Optional.of(new Diary(id, trashCan.get(id)));
+        return Optional.of(trashCan.get(id));
     }
 
-    protected void remove(long diaryId) {
+    protected void remove(final long diaryId) {
         trashCan.remove(diaryId);
     }
 }

--- a/src/main/java/org/sopt/week1/TrashBin.java
+++ b/src/main/java/org/sopt/week1/TrashBin.java
@@ -1,0 +1,21 @@
+package org.sopt.week1;
+
+import org.sopt.week1.Main.UI.InvalidInputException;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TrashBin {
+    private final Map<Long, String> trashCan = new ConcurrentHashMap<>();
+
+    protected void pile(Diary diary) {
+        trashCan.put(diary.getId(), diary.getBody());
+    }
+
+    protected Diary restore(long id) {
+        if (!trashCan.containsKey(id)) {
+            throw new InvalidInputException("삭제되지 않는 id 입니다.");
+        }
+        return new Diary(id, trashCan.get(id));
+    }
+}

--- a/src/main/java/org/sopt/week1/TrashBin.java
+++ b/src/main/java/org/sopt/week1/TrashBin.java
@@ -1,7 +1,5 @@
 package org.sopt.week1;
 
-import org.sopt.week1.Main.UI.InvalidInputException;
-
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -18,5 +16,9 @@ public class TrashBin {
             return Optional.empty();
         }
         return Optional.of(new Diary(id, trashCan.get(id)));
+    }
+
+    protected void remove(long diaryId) {
+        trashCan.remove(diaryId);
     }
 }

--- a/src/main/java/org/sopt/week1/TrashBin.java
+++ b/src/main/java/org/sopt/week1/TrashBin.java
@@ -3,6 +3,7 @@ package org.sopt.week1;
 import org.sopt.week1.Main.UI.InvalidInputException;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class TrashBin {
@@ -12,10 +13,10 @@ public class TrashBin {
         trashCan.put(diary.getId(), diary.getBody());
     }
 
-    protected Diary restore(long id) {
+    protected Optional<Diary> restore(long id) {
         if (!trashCan.containsKey(id)) {
-            throw new InvalidInputException("삭제되지 않는 id 입니다.");
+            return Optional.empty();
         }
-        return new Diary(id, trashCan.get(id));
+        return Optional.of(new Diary(id, trashCan.get(id)));
     }
 }


### PR DESCRIPTION
# ⭐ 세부 과제 목록
- [x]  삭제된 일기를 복구하는 기능 추가
- [x]  일기 수정 일일 2회 제한 기능 추가
- [ ]  Application 종료 시에도 일기 저장 목록이 유지되는 기능 추가
- [ ]  한 줄 일기의 글자수 제한은 유지하면서, 이모지를 넣을 수 있도록 구현

## 1. 삭제된 일기 복구 기능 추가
<img width="260" alt="image" src="https://github.com/user-attachments/assets/77520de6-03b8-4c2c-a649-966b7d196338">
<img width="285" alt="image" src="https://github.com/user-attachments/assets/a639e436-c655-43e0-8138-7e44fe3656dd">

### 고민 과정
- **어떻게 구현할 것인가?**
모든 노트북에 존재하는 휴지통처럼, 삭제된 일기들을 저장하는 저장소를 만드는 방법과 Diary객체에 isDeleted 필드를 두어 soft delete하는 방식으로 구현하는 방법 중 고민하였습니다. 이미 작성된 로직들을 최대한 변경하지 않고 복구 기능을 구현할 수 있는 방법은 전자의 방법이라 생각하였기 때문에 전자의 방식으로 구현하였습니다. (후자의 방법의 경우, 조회하는 경우부터 검증하는 로직까지 'isDeleted가 false인 경우'라는 조건을 추가적으로 설정해주어야 하기 때문에 변경이 많을 것이라 생각하였는데 지금 생각해보니 후자의 방법도 괜찮았을 것 같다는 생각이 듭니다.) 
- **예외처리를 어느 범위까지 할 것인가?**
 현재 로직은 삭제된 일기들을 저장하는 저장소가 존재하고, 삭제된 일기의 Id 값을 토대로 저장소에서 복구하는 방법으로 동작합니다. 현재는 TrashCan 안에 저장되어 있지 않은 id가 입력 값으로 들어올 경우에만 예외가 발생하도록 하였습니다. 하지만 이에 더해 추가적으로, storage에 저장된 id일 경우, 즉 삭제되지 않은 id가 입력 값으로 들어왔을 경우에 대해서도 이중적으로 예외처리를 추가해주어야 할 지 고민했습니다. -> 로직이 수행될 때, 삭제되지 않은 id는 TrashCan 저장소에 절대 저장될 리 없기에 추가적인 예외처리를 해주지 않기로 하였습니다.

### 구현
```
public class TrashBin {
    private final Map<Long, Diary> trashCan = new ConcurrentHashMap<>();

    protected void pile(final Diary diary) {
        trashCan.put(diary.getId(), diary);
    }

    protected Optional<Diary> restore(final long id) {
        if (!trashCan.containsKey(id)) {
            return Optional.empty();
        }
        return Optional.of(trashCan.get(id));
    }

    protected void remove(final long diaryId) {
        trashCan.remove(diaryId);
    }
}
```

삭제된 일기들을 저장해두는 TrashBin 객체를 생성하였습니다. 역할은 `DiaryRepository`와 유사합니다. 일기가 삭제되면 `pile` 메서드를 호출하여 삭제된 일기들을 Map 형태의 저장소, trashCan에 저장하고 복구 명령이 들어오면, `restore` 메서드를 호출하여, 해당 id가 존재할 경우에 대해, 다시 storage에 저장하였습니다. 이렇게 복구가 완료되면, trashCan 저장소에 저장되어있던 id를 삭제하는 방식으로 구현하였습니다.

## 2. 일기 수정 일일 2회 제한 기능 추가
<img width="243" alt="image" src="https://github.com/user-attachments/assets/ff2b27f3-5ee9-4f80-8e73-1d80acef48e8">
<img width="233" alt="image" src="https://github.com/user-attachments/assets/545acfa4-5065-4f81-956a-2e53b63ce1b8">
<img width="262" alt="image" src="https://github.com/user-attachments/assets/2f540f2d-e92d-4e5d-bfd5-4a18d4881ed3">

### 고민 과정
일일 수정 기능을 2회로 제한하기 위해서는 저장소에 저장된 Diary 객체가 수정 횟수와, 수정 날짜 정보를 알고 있어야 한다고 생각했습니다.
- **객체를 분리하여 관리할 것인가?**
이때, 날짜 정보와 수정 횟수 정보를 Diary 객체의 필드로써 관리를 할 지, 아니면 새로운 객체를 만들어 관리할 지 고민했습니다.
- **날짜 비교를 어떻게 할 것인가?**
 하루가 지나면, 수정 횟수를 다시 0회로 초기화 시키는 방법에 대해 고민하던 중, Java의 LocalDate 객체가 제공하는 API 중, 매개변수로 전달된 LocalDate 객체보다 이전 날짜인지 체크하는 `isBefore` 메서드에 대해서 알게 되었고, 이를 활용하였습니다.

### 구현
```
public class ReviseInfo {
    private static final int REVISE_LIMIT = 2;
    private LocalDate reviseDate;
    private int reviseCount;

    public ReviseInfo() {
        this.reviseDate = LocalDate.now();
        this.reviseCount = 0;
    }
}
```
```
public class Diary {
    private Long id;
    private String body;
    private final ReviseInfo reviseInfo;
}
```
수정된 횟수와 수정된 날짜를 담고 있는 `ReviseInfo` 객체를 따로 만들고 이 객체를 Diary 객체의 필드로 사용하는 방식으로 구현하였습니다. 수정횟수와 수정 날짜 사이에는 긴밀한 연관이 존재하고 자주 변경되지만, 이 2개의 정보가 변경될 때, Diary 객체에 이미 존재하는 필드인 body와 id 값과는 큰 상관관계가 없어 보였기에, 수정과 관련된 정보를 관리하는 역할을 하는 새로운 객체를 만들고, 그 객체에서 그 정보들을 관리하는 것이 역할과 책임이 명확히 분리될 것이라 생각하였습니다!

```
public boolean checkReviseCount() {
        if (reviseInfo.getReviseDate().isBefore(LocalDate.now())) {
            reviseInfo.resetReviseCount();
        }
        return reviseInfo.checkReviseCount();
    }
```
해당 메소드는, 사용자가 일기를 수정하려는 그 시점과 해당 일기의 마지막 수정일자를 비교하여, 하루가 지났을 경우, 수정 횟수를 0회로 초기화하도록 하였고 최종적으로 일일 제한 횟수 2회 초과 유무를 boolean값으로 반환하도록 하였습니다. 수정횟수를 초기화하는 로직에 대해 따로 함수 분리를 할까 고민하였지만, 결국 '수정 횟수를 확인'하는 과정에서 필요한 로직이라고 생각하였기 때문에, 수정 가능 여부를 확인하는 로직에 함께 포함하였습니다. 최종적으로 service 단에서 해당 메서드를 호출하여, 수정이 불가능하다는 결과값(false)을 반환하게 된다면 예외를 던지도록 구현하였습니다.
```
private final Map<Long, Diary> storage = new ConcurrentHashMap<>();
```
본래 id 값과 일기의 본문인 String 값을 저장하고 있는 저장소를 Diary 객체 그 자체를 저장할 수 있도록 수정하였습니다. 이렇게 수정함으로써, `findById` 메서드를 실행할 때, id 값과 일치하는 Diary 객체를 바로 반환할 수 있도록 하였습니다.
-> 기존의 코드에서는 id값을 토대로 매번 새로운 Diary 객체를 반환하는 방식으로 구현되어 있어 메모리 낭비가 발생하였고 수정시, 해당 일기 객체의 정확한 추적이 어려웠기 때문에 Diary 객체를 저장하는 방식으로 수정하였습니다.